### PR TITLE
:bug: Remove redundant check for git token

### DIFF
--- a/pkg/github/client/credentials.go
+++ b/pkg/github/client/credentials.go
@@ -69,11 +69,7 @@ func NewGitConfig() (GitConfig, error) {
 	}
 	gitCfg.GitRepoName = val
 
-	val, ok = os.LookupEnv(EnvGitAccessToken)
-	if val == "" || !ok {
-		return GitConfig{}, fmt.Errorf("environment variable %s is not set", EnvGitAccessToken)
-	}
-	gitCfg.GitAccessToken = val
+	gitCfg.GitAccessToken = os.Getenv(EnvGitAccessToken)
 
 	return gitCfg, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing the redundant check for the git token that breaks in open-source repos where there is no need for a token

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

