### PR TITLE
:bug: Fix deleting resources from Helm charts

### DIFF
--- a/internal/controller/clusteraddon_controller.go
+++ b/internal/controller/clusteraddon_controller.go
@@ -200,6 +200,7 @@ func (r *ClusterAddonReconciler) Reconcile(ctx context.Context, req reconcile.Re
 
 			shouldRequeue, err := r.templateAndApplyClusterAddonHelmChart(ctx, in)
 			if err != nil {
+				conditions.MarkFalse(clusterAddon, csov1alpha1.HelmChartAppliedCondition, csov1alpha1.FailedToApplyObjectsReason, clusterv1.ConditionSeverityError, "failed to apply")
 				return ctrl.Result{}, fmt.Errorf("failed to apply helm chart: %w", err)
 			}
 			if shouldRequeue {
@@ -240,6 +241,7 @@ func (r *ClusterAddonReconciler) Reconcile(ctx context.Context, req reconcile.Re
 
 		shouldRequeue, err := r.templateAndApplyClusterAddonHelmChart(ctx, in)
 		if err != nil {
+			conditions.MarkFalse(clusterAddon, csov1alpha1.HelmChartAppliedCondition, csov1alpha1.FailedToApplyObjectsReason, clusterv1.ConditionSeverityError, "failed to apply")
 			return ctrl.Result{}, fmt.Errorf("failed to apply helm chart: %w", err)
 		}
 		if shouldRequeue {

--- a/pkg/kube/helpers.go
+++ b/pkg/kube/helpers.go
@@ -105,17 +105,13 @@ func parseK8sYaml(template []byte) ([]*unstructured.Unstructured, error) {
 	return objs, nil
 }
 
-func getResourceMap(resources []*csov1alpha1.Resource) (resourceMap map[types.NamespacedName]*csov1alpha1.Resource, notToApply []*csov1alpha1.Resource) {
-	resourceMap = make(map[types.NamespacedName]*csov1alpha1.Resource)
-	notToApply = make([]*csov1alpha1.Resource, 0, len(resources))
+func getResourceMap(resources []*csov1alpha1.Resource) map[types.NamespacedName]*csov1alpha1.Resource {
+	resourceMap := make(map[types.NamespacedName]*csov1alpha1.Resource)
 
 	for i, resource := range resources {
-		if resource.Status == csov1alpha1.ResourceStatusSynced {
-			notToApply = append(notToApply, resources[i])
-		}
 		resourceMap[types.NamespacedName{Name: resource.Name, Namespace: resource.Namespace}] = resources[i]
 	}
-	return resourceMap, notToApply
+	return resourceMap
 }
 
 func setLabel(target *unstructured.Unstructured, key, val string) error {

--- a/pkg/kube/mocks/Client.go
+++ b/pkg/kube/mocks/Client.go
@@ -62,39 +62,6 @@ func (_m *Client) Delete(template []byte) error {
 	return r0
 }
 
-// Update provides a mock function with given fields: ctx, template, oldResources
-func (_m *Client) Update(ctx context.Context, template []byte, oldResources []*v1alpha1.Resource) ([]*v1alpha1.Resource, bool, error) {
-	ret := _m.Called(ctx, template, oldResources)
-
-	var r0 []*v1alpha1.Resource
-	var r1 bool
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, []byte, []*v1alpha1.Resource) ([]*v1alpha1.Resource, bool, error)); ok {
-		return rf(ctx, template, oldResources)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, []byte, []*v1alpha1.Resource) []*v1alpha1.Resource); ok {
-		r0 = rf(ctx, template, oldResources)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*v1alpha1.Resource)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, []byte, []*v1alpha1.Resource) bool); ok {
-		r1 = rf(ctx, template, oldResources)
-	} else {
-		r1 = ret.Get(1).(bool)
-	}
-
-	if rf, ok := ret.Get(2).(func(context.Context, []byte, []*v1alpha1.Resource) error); ok {
-		r2 = rf(ctx, template, oldResources)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
 // NewClient creates a new instance of Client. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewClient(t interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
There are two problems with deleting resources from Helm charts right now: The first one is that the objects stay in the status.resources list, even after they are deleted. The second is that instead of returning an error when a deletion failed, we returned an error on success.

Instead, as we base deletion of objects based on the status.resources list (this can be changed in the future), we keep resources that are supposed to be deleted but failed to in the status as not-synced. Additionally, we requeue and try the deletion another time, just as we do with applying currently.

As the current Update method is unused since we changed from create to apply, it is deleted. Mocks are generated freshly as well.

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

