### PR TITLE
:seedling: use v2 for `make tilt-up` and provide Docker socket

### DIFF
--- a/config/cso/cluster.yaml
+++ b/config/cso/cluster.yaml
@@ -11,7 +11,7 @@ spec:
       cidrBlocks: ["192.168.0.0/16"]
     serviceDomain: "cluster.local"
   topology:
-    class: docker-ferrol-1-27-v1
+    class: docker-ferrol-1-27-v2
     controlPlane:
       metadata: {}
       replicas: 1

--- a/config/cso/clusterstack.yaml
+++ b/config/cso/clusterstack.yaml
@@ -11,4 +11,4 @@ spec:
   autoSubscribe: false
   noProvider: true
   versions:
-    - v1
+    - v2

--- a/docs/develop/develop.md
+++ b/docs/develop/develop.md
@@ -18,7 +18,7 @@ Operator development requires a lot of iteration, and the “build, tag, push, u
 ```shell
 make tilt-up
 ```
-> To access the Tilt UI please go to: `http://localhost:10350`
+> To access the Tilt UI please go to: `http://localhost:10351`
 
 
 You should make sure that everything in the UI looks green. If not, e.g. if the clusterstack has not been synced, you can trigger the Tilt workflow again. In case of the clusterstack button this might be necessary, as it cannot be applied right after startup of the cluster and fails. Tilt unfortunately does not include a waiting period.

--- a/hack/kind-dev.sh
+++ b/hack/kind-dev.sh
@@ -44,6 +44,9 @@ kindV1Alpha4Cluster:
   nodes:
   - role: control-plane
     image: kindest/node:${CLUSTER_VERSION}
+    extraMounts:
+    - hostPath: /var/run/docker.sock
+      containerPath: /var/run/docker.sock
   networking:
     podSubnet: "10.244.0.0/16"
     serviceSubnet: "10.96.0.0/12"


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR changes the kind cluster, so that the docker socket of the host is available in the mgt-cluster.

Otherwise, you get:

> Reconciler error" err="failed to create helper for managing the
> externalLoadBalancer: failed to list containers: failed to list containers:
> failed to list containers: Cannot connect to the Docker daemon
>  at unix:///var/run/docker.sock. Is the docker daemon running?

