### PR TITLE
🐛 fix upgrade builder image script

### DIFF
--- a/hack/upgrade-builder-image.sh
+++ b/hack/upgrade-builder-image.sh
@@ -35,7 +35,7 @@ if [ "${CI:-false}" = true ] ; then
 echo $BUILD_IMAGE_TOKEN | docker login ghcr.io -u $BUILD_IMAGE_USER --password-stdin
 fi
 
-export VERSION=$(git fetch --quiet origin main && git show origin/main:Makefile | grep "BUILDER_IMAGE_VERSION :=" | sed 's/.*BUILDER_IMAGE_VERSION := //' | sed 's/\s.*$//' )
+export VERSION=$(git fetch --quiet origin main && git show origin/main:.builder-image-version.txt)
 export NEW_VERSION=$(semver_upgrade patch ${VERSION})
 
 if docker manifest inspect ghcr.io/sovereigncloudstack/cso-builder:${VERSION} > /dev/null ; echo $?; then


### PR DESCRIPTION
when I initially worked on this, this was hardcoded and we were using grep + sed combination to get
version. Later we switched to track version by
using a file at the root of the repo.
The file was .builder-image-version.txt, this was
a bug where we were still reading from Makefile
hardcoded version.
This commit fixes the same and switches to new
method where we read from .builder-image-version.txt
