### PR TITLE
🌱 automate adding labels to pull requests

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,16 +1,25 @@
 ---
 area/code:
-  - "controllers/**/*"
-  - "pkg/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "controllers/**/*"
+      - any-glob-to-any-file: "pkg/**/*"
 area/api:
-  - "api/**/*"
-  - "config/crd/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "api/**/*"
+      - any-glob-to-any-file: "config/crd/**/*"
 area/github:
-  - ".github/**/*"
+  - changed-files:
+      - any-glob-to-any-file: ".github/**/*"
 area/hack:
-  - "hack/**/*"
-  - "Makefile"
+  - changed-files:
+      - any-glob-to-any-file: "hack/**/*"
+      - any-glob-to-any-file: "Makefile"
 area/test:
-  - "test/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "test/**/*"
 area/templates:
-  - "templates/**/*"
+  - changed-files:
+      - any-glob-to-any-file: "templates/**/*"
+Container:
+  - changed-files:
+      - any-glob-to-any-file: '**'

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -78,3 +78,7 @@
   color: "7B55D7"
 - name: question
   color: "cc317c"
+- name: Container
+  color: "0dce67"
+  description: >-
+    Container Infra and Tooling.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,4 +44,5 @@
   separateMinorPatch: true,
   enabledManagers: ["dockerfile", "gomod", "github-actions", "regex"],
   recreateClosed: true,
+  labels: ["Container"]
 }

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.5.0
         with:
-          project-url: https://github.com/orgs/SovereignCloudStack/projects/6/views/7
+          project-url: https://github.com/orgs/SovereignCloudStack/projects/6
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: Container
           label-operator: AND

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,0 +1,29 @@
+name: Label issues And add to projects
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: Container
+
+  add-to-project:
+    name: Add pull request to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/SovereignCloudStack/projects/6/views/7
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: Container
+          label-operator: AND

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -22,3 +22,22 @@ jobs:
 
       - name: Verify Shellcheck
         run: make verify-shellcheck
+
+      - name: Generate Token
+        uses: actions/create-github-app-token@e8e39f73bb84fdf315a015fa3104f314c0a258b4 # v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.SCS_APP_ID }}
+          private-key: ${{ secrets.SCS_APP_PRIVATE_KEY }}
+
+      - name: Generate Labels
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+        with:
+          configuration-path: .github/labeler.yaml
+          repo-token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Sync Labels
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2
+        with:
+          config-file: .github/labels.yaml
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
this commit uses actions/labeler to automate
adding Container labels to pull requests.
For renovate PRs, it extends renovate
configuration so that renovate adds Container
label to the PR when a new dependency upgrade
pull request is created.

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/SovereignCloudStack/cluster-stack-operator/issues/93

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

