### PR TITLE
:seedling: allow renovate to propagate builder image version

### DIFF
--- a/.github/workflows/schedule-update-bot.yaml
+++ b/.github/workflows/schedule-update-bot.yaml
@@ -50,7 +50,7 @@ jobs:
           RENOVATE_HOST_RULES: '[{"hostType": "docker", "matchHost": "ghcr.io", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}" }]'
           RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '[".*"]'
           BUILDER_IMAGE: 'ghcr.io/sovereigncloudstack/cso'
-          RENOVATE_POST_UPGRADE_TASKS: '{ commands: ["BUILD_IMAGE_TOKEN=${{ secrets.GITHUB_TOKEN }} BUILD_IMAGE_USER=${{ github.actor }} CI=true ./hack/upgrade-builder-image.sh"], fileFilters: ["Makefile", ".github/**/*.yml", ".github/**/*.yaml"], executionMode: "branch"}'
+          RENOVATE_POST_UPGRADE_TASKS: '{ commands: ["BUILD_IMAGE_TOKEN=${{ secrets.GITHUB_TOKEN }} BUILD_IMAGE_USER=${{ github.actor }} CI=true ./hack/upgrade-builder-image.sh"], fileFilters: ["Makefile", ".builder-image-version.txt", ".github/**/*.yml", ".github/**/*.yaml"], executionMode: "branch"}'
         with:
           configurationFile: ${{ env.RENOVATE_CONFIG_FILE }}
           token: "x-access-token:${{ steps.generate-token.outputs.token }}"

--- a/hack/upgrade-builder-image.sh
+++ b/hack/upgrade-builder-image.sh
@@ -38,6 +38,9 @@ fi
 export VERSION=$(git fetch --quiet origin main && git show origin/main:.builder-image-version.txt)
 export NEW_VERSION=$(semver_upgrade patch ${VERSION})
 
+echo "$NEW_VERSION" > .builder-image-version.txt
+echo "Wrote new version $NEW_VERSION to .builder-image-version.txt"
+
 if docker manifest inspect ghcr.io/sovereigncloudstack/cso-builder:${VERSION} > /dev/null ; echo $?; then
 
   sed -i -e "/^BUILDER_IMAGE_VERSION /s/:=.*$/:= ${NEW_VERSION}/" Makefile


### PR DESCRIPTION
- **allow renovate to propagate builder image version**
  As of now, renovate only populates the updated
  version in github workflows but don't write
  to .builder-image-version.txt which is the main
  part.
  This commit fixes the same.
  
  Signed-off-by: kranurag7 <anurag.kumar@syself.com>