### PR TITLE
:seedling: use cosign attest and upgrade bom

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Bom
         shell: bash
         run: |
-          curl -L https://github.com/kubernetes-sigs/bom/releases/download/v0.4.1/bom-linux-amd64 -o bom
+          curl -L https://github.com/kubernetes-sigs/bom/releases/download/v0.6.0/bom-amd64-linux -o bom
           sudo mv ./bom /usr/local/bin/bom
           sudo chmod +x /usr/local/bin/bom
 
@@ -77,8 +77,6 @@ jobs:
           cache-to: type=gha, mode=max, scope=${{ github.workflow }}
 
       - name: Sign Container Images
-        env:
-          COSIGN_EXPERIMENTAL: "true"
         run: |
           cosign sign --yes ghcr.io/sovereigncloudstack/cso@${{ steps.docker_build_release_cso.outputs.digest }}
 
@@ -87,16 +85,14 @@ jobs:
         # To-Do: generate SBOM from source after https://github.com/kubernetes-sigs/bom/issues/202 is fixed
         # To-Do: format SBOM output to json after cosign v2.0 is released with https://github.com/sigstore/cosign/pull/2479
         run: |
-          bom generate -o sbom_ci_main_cso_${{ steps.metacso.outputs.version }}.spdx \
+          bom generate -o sbom_ci_main_cso_${{ steps.metacso.outputs.version }}-spdx.json \
           --image=ghcr.io/sovereigncloudstack/cso:${{ steps.metacso.outputs.version }}
 
       - name: Attach SBOM to Container Images cso
         run: |
-          cosign attach sbom --sbom sbom_ci_main_cso_${{ steps.metacso.outputs.version }}.spdx ghcr.io/sovereigncloudstack/cso@${{ steps.docker_build_release_cso.outputs.digest }}
+          cosign attest --yes --type=spdxjson --predicate sbom_ci_main_cso_${{ steps.metacso.outputs.version }}-spdx.json ghcr.io/sovereigncloudstack/cso@${{ steps.docker_build_release_cso.outputs.digest }}
 
       - name: Sign SBOM Images cso
-        env:
-          COSIGN_EXPERIMENTAL: "true"
         run: |
           docker_build_release_digest="${{ steps.docker_build_release_cso.outputs.digest }}"
           image_name="ghcr.io/sovereigncloudstack/cso:${docker_build_release_digest/:/-}.sbom"


### PR DESCRIPTION
Fixes #99

- **use cosign attest and upgrade bom**
  this commit does two things:
  1. upgrades kubernetes-sigs/bom to the latest version.
  2. It uses cosign attest as replacement to deprecated cosign attach
  command.
  
  Signed-off-by: kranurag7 <anurag.kumar@syself.com>