### PR TITLE
🌱 use scs capd image while using docker provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ env-vars-for-wl-cluster:
 .PHONY: delete-bootstrap-cluster
 delete-bootstrap-cluster: $(CTLPTL)  ## Deletes Kind-dev Cluster
 	$(CTLPTL) delete cluster kind-cso
-	$(CTLPTL) delete registry cso-registry
+	$(CTLPTL) delete registry kind-registry
 
 .PHONY: cluster
 cluster: $(CTLPTL) $(KUBECTL) ## Creates kind-dev Cluster

--- a/Tiltfile
+++ b/Tiltfile
@@ -62,11 +62,9 @@ def deploy_capi():
                 patch_args_with_extra_args("capi-kubeadm-bootstrap-system", "capi-kubeadm-bootstrap-controller-manager", kb_extra_args)
 
 def deploy_capd():
-    version = settings.get("capi_version")
-    capd_uri = "https://github.com/kubernetes-sigs/cluster-api/releases/download/{}/infrastructure-components-development.yaml".format(version)
-    cmd = "curl -sSL {} | {} | kubectl apply -f -".format(capd_uri, envsubst_cmd)
+    yaml = './capd.yaml'
+    cmd = "kubectl apply -f capd.yaml"
     local(cmd, quiet = True)
-
 
 def prepare_environment():
     local("kubectl create namespace cluster --dry-run=client -o yaml | kubectl apply -f -")

--- a/capd.yaml
+++ b/capd.yaml
@@ -1,0 +1,2266 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    control-plane: controller-manager
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: capd-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: dockerclusters.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerCluster
+    listKind: DockerClusterList
+    plural: dockerclusters
+    singular: dockercluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "DockerCluster is the Schema for the dockerclusters API. \n Deprecated:
+          This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerClusterSpec defines the desired state of DockerCluster.
+            properties:
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: Host is the hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: Port is the port on which the API server is serving.
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains are not usulaly defined on the spec. The
+                  docker provider is special since failure domains don't mean anything
+                  in a local docker environment. Instead, the docker cluster controller
+                  will simply copy these into the Status and allow the Cluster API
+                  controllers to do what they will with the defined failure domains.
+                type: object
+              loadBalancer:
+                description: LoadBalancer allows defining configurations for the cluster
+                  load balancer.
+                properties:
+                  imageRepository:
+                    description: ImageRepository sets the container registry to pull
+                      the haproxy image from. if not set, "kindest" will be used instead.
+                    type: string
+                  imageTag:
+                    description: ImageTag allows to specify a tag for the haproxy
+                      image. if not set, "v20210715-a6da3463" will be used instead.
+                    type: string
+                type: object
+            type: object
+          status:
+            description: DockerClusterStatus defines the observed state of DockerCluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the DockerCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains don't mean much in CAPD since it's all
+                  local, but we can see how the rest of cluster API will use this
+                  if we populate it.
+                type: object
+              ready:
+                description: Ready denotes that the docker cluster (infrastructure)
+                  is ready.
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Time duration since creation of DockerCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerCluster is the Schema for the dockerclusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerClusterSpec defines the desired state of DockerCluster.
+            properties:
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: Host is the hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: Port is the port on which the API server is serving.
+                      Defaults to 6443 if not set.
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains are usually not defined in the spec. The
+                  docker provider is special since failure domains don't mean anything
+                  in a local docker environment. Instead, the docker cluster controller
+                  will simply copy these into the Status and allow the Cluster API
+                  controllers to do what they will with the defined failure domains.
+                type: object
+              loadBalancer:
+                description: LoadBalancer allows defining configurations for the cluster
+                  load balancer.
+                properties:
+                  customHAProxyConfigTemplateRef:
+                    description: 'CustomHAProxyConfigTemplateRef allows you to replace
+                      the default HAProxy config file. This field is a reference to
+                      a config map that contains the configuration template. The key
+                      of the config map should be equal to ''value''. The content
+                      of the config map will be processed and will replace the default
+                      HAProxy config file. Please use it with caution, as there are
+                      no checks to ensure the validity of the configuration. This
+                      template will support the following variables that will be passed
+                      by the controller: $IPv6 (bool) indicates if the cluster is
+                      IPv6, $FrontendControlPlanePort (string) indicates the frontend
+                      control plane port, $BackendControlPlanePort (string) indicates
+                      the backend control plane port, $BackendServers (map[string]string)
+                      indicates the backend server where the key is the server name
+                      and the value is the address. This map is dynamic and is updated
+                      every time a new control plane node is added or removed. The
+                      template will also support the JoinHostPort function to join
+                      the host and port of the backend server.'
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  imageRepository:
+                    description: ImageRepository sets the container registry to pull
+                      the haproxy image from. if not set, "kindest" will be used instead.
+                    type: string
+                  imageTag:
+                    description: ImageTag allows to specify a tag for the haproxy
+                      image. if not set, "v20210715-a6da3463" will be used instead.
+                    type: string
+                type: object
+            type: object
+          status:
+            description: DockerClusterStatus defines the observed state of DockerCluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the DockerCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains don't mean much in CAPD since it's all
+                  local, but we can see how the rest of cluster API will use this
+                  if we populate it.
+                type: object
+              ready:
+                description: Ready denotes that the docker cluster (infrastructure)
+                  is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: dockerclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerClusterTemplate
+    listKind: DockerClusterTemplateList
+    plural: dockerclustertemplates
+    singular: dockerclustertemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerClusterTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "DockerClusterTemplate is the Schema for the dockerclustertemplates
+          API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerClusterTemplateSpec defines the desired state of DockerClusterTemplate.
+            properties:
+              template:
+                description: DockerClusterTemplateResource describes the data needed
+                  to create a DockerCluster from a template.
+                properties:
+                  spec:
+                    description: DockerClusterSpec defines the desired state of DockerCluster.
+                    properties:
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint represents the endpoint
+                          used to communicate with the control plane.
+                        properties:
+                          host:
+                            description: Host is the hostname on which the API server
+                              is serving.
+                            type: string
+                          port:
+                            description: Port is the port on which the API server
+                              is serving.
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      failureDomains:
+                        additionalProperties:
+                          description: FailureDomainSpec is the Schema for Cluster
+                            API failure domains. It allows controllers to understand
+                            how many failure domains a cluster can optionally span
+                            across.
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: Attributes is a free form map of attributes
+                                an infrastructure provider might use or require.
+                              type: object
+                            controlPlane:
+                              description: ControlPlane determines if this failure
+                                domain is suitable for use by control plane machines.
+                              type: boolean
+                          type: object
+                        description: FailureDomains are not usulaly defined on the
+                          spec. The docker provider is special since failure domains
+                          don't mean anything in a local docker environment. Instead,
+                          the docker cluster controller will simply copy these into
+                          the Status and allow the Cluster API controllers to do what
+                          they will with the defined failure domains.
+                        type: object
+                      loadBalancer:
+                        description: LoadBalancer allows defining configurations for
+                          the cluster load balancer.
+                        properties:
+                          imageRepository:
+                            description: ImageRepository sets the container registry
+                              to pull the haproxy image from. if not set, "kindest"
+                              will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the
+                              haproxy image. if not set, "v20210715-a6da3463" will
+                              be used instead.
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerClusterTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerClusterTemplate is the Schema for the dockerclustertemplates
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerClusterTemplateSpec defines the desired state of DockerClusterTemplate.
+            properties:
+              template:
+                description: DockerClusterTemplateResource describes the data needed
+                  to create a DockerCluster from a template.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: DockerClusterSpec defines the desired state of DockerCluster.
+                    properties:
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint represents the endpoint
+                          used to communicate with the control plane.
+                        properties:
+                          host:
+                            description: Host is the hostname on which the API server
+                              is serving.
+                            type: string
+                          port:
+                            description: Port is the port on which the API server
+                              is serving. Defaults to 6443 if not set.
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      failureDomains:
+                        additionalProperties:
+                          description: FailureDomainSpec is the Schema for Cluster
+                            API failure domains. It allows controllers to understand
+                            how many failure domains a cluster can optionally span
+                            across.
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: Attributes is a free form map of attributes
+                                an infrastructure provider might use or require.
+                              type: object
+                            controlPlane:
+                              description: ControlPlane determines if this failure
+                                domain is suitable for use by control plane machines.
+                              type: boolean
+                          type: object
+                        description: FailureDomains are usually not defined in the
+                          spec. The docker provider is special since failure domains
+                          don't mean anything in a local docker environment. Instead,
+                          the docker cluster controller will simply copy these into
+                          the Status and allow the Cluster API controllers to do what
+                          they will with the defined failure domains.
+                        type: object
+                      loadBalancer:
+                        description: LoadBalancer allows defining configurations for
+                          the cluster load balancer.
+                        properties:
+                          customHAProxyConfigTemplateRef:
+                            description: 'CustomHAProxyConfigTemplateRef allows you
+                              to replace the default HAProxy config file. This field
+                              is a reference to a config map that contains the configuration
+                              template. The key of the config map should be equal
+                              to ''value''. The content of the config map will be
+                              processed and will replace the default HAProxy config
+                              file. Please use it with caution, as there are no checks
+                              to ensure the validity of the configuration. This template
+                              will support the following variables that will be passed
+                              by the controller: $IPv6 (bool) indicates if the cluster
+                              is IPv6, $FrontendControlPlanePort (string) indicates
+                              the frontend control plane port, $BackendControlPlanePort
+                              (string) indicates the backend control plane port, $BackendServers
+                              (map[string]string) indicates the backend server where
+                              the key is the server name and the value is the address.
+                              This map is dynamic and is updated every time a new
+                              control plane node is added or removed. The template
+                              will also support the JoinHostPort function to join
+                              the host and port of the backend server.'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          imageRepository:
+                            description: ImageRepository sets the container registry
+                              to pull the haproxy image from. if not set, "kindest"
+                              will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the
+                              haproxy image. if not set, "v20210715-a6da3463" will
+                              be used instead.
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: dockermachinepools.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerMachinePool
+    listKind: DockerMachinePoolList
+    plural: dockermachinepools
+    singular: dockermachinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "DockerMachinePool is the Schema for the dockermachinepools API.
+          \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachinePoolSpec defines the desired state of DockerMachinePool.
+            properties:
+              providerID:
+                description: ProviderID is the identification ID of the Machine Pool
+                type: string
+              providerIDList:
+                description: ProviderIDList is the list of identification IDs of machine
+                  instances managed by this Machine Pool
+                items:
+                  type: string
+                type: array
+              template:
+                description: Template contains the details used to build a replica
+                  machine within the Machine Pool
+                properties:
+                  customImage:
+                    description: CustomImage allows customizing the container image
+                      that is used for running the machine
+                    type: string
+                  extraMounts:
+                    description: ExtraMounts describes additional mount points for
+                      the node container These may be used to bind a hostPath
+                    items:
+                      description: Mount specifies a host volume to mount into a container.
+                        This is a simplified version of kind v1alpha4.Mount types.
+                      properties:
+                        containerPath:
+                          description: Path of the mount within the container.
+                          type: string
+                        hostPath:
+                          description: Path of the mount on the host. If the hostPath
+                            doesn't exist, then runtimes should report error. If the
+                            hostpath is a symbolic link, runtimes should follow the
+                            symlink and mount the real destination to container.
+                          type: string
+                        readOnly:
+                          description: If set, the mount is read-only.
+                          type: boolean
+                      type: object
+                    type: array
+                  preLoadImages:
+                    description: PreLoadImages allows to pre-load images in a newly
+                      created machine. This can be used to speed up tests by avoiding
+                      e.g. to download CNI images on all the containers.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+          status:
+            description: DockerMachinePoolStatus defines the observed state of DockerMachinePool.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the DockerMachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              instances:
+                description: Instances contains the status for each instance in the
+                  pool
+                items:
+                  description: DockerMachinePoolInstanceStatus contains status information
+                    about a DockerMachinePool.
+                  properties:
+                    addresses:
+                      description: Addresses contains the associated addresses for
+                        the docker machine.
+                      items:
+                        description: MachineAddress contains information for the node's
+                          address.
+                        properties:
+                          address:
+                            description: The machine address.
+                            type: string
+                          type:
+                            description: Machine address type, one of Hostname, ExternalIP
+                              or InternalIP.
+                            type: string
+                        required:
+                        - address
+                        - type
+                        type: object
+                      type: array
+                    bootstrapped:
+                      description: Bootstrapped is true when the kubeadm bootstrapping
+                        has been run against this machine
+                      type: boolean
+                    instanceName:
+                      description: InstanceName is the identification of the Machine
+                        Instance within the Machine Pool
+                      type: string
+                    providerID:
+                      description: ProviderID is the provider identification of the
+                        Machine Pool Instance
+                      type: string
+                    ready:
+                      description: Ready denotes that the machine (docker container)
+                        is ready
+                      type: boolean
+                    version:
+                      description: Version defines the Kubernetes version for the
+                        Machine Instance
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the machine pool is ready
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerMachinePool is the Schema for the dockermachinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachinePoolSpec defines the desired state of DockerMachinePool.
+            properties:
+              providerID:
+                description: ProviderID is the identification ID of the Machine Pool
+                type: string
+              providerIDList:
+                description: ProviderIDList is the list of identification IDs of machine
+                  instances managed by this Machine Pool
+                items:
+                  type: string
+                type: array
+              template:
+                description: Template contains the details used to build a replica
+                  machine within the Machine Pool
+                properties:
+                  customImage:
+                    description: CustomImage allows customizing the container image
+                      that is used for running the machine
+                    type: string
+                  extraMounts:
+                    description: ExtraMounts describes additional mount points for
+                      the node container These may be used to bind a hostPath
+                    items:
+                      description: Mount specifies a host volume to mount into a container.
+                        This is a simplified version of kind v1alpha4.Mount types.
+                      properties:
+                        containerPath:
+                          description: Path of the mount within the container.
+                          type: string
+                        hostPath:
+                          description: Path of the mount on the host. If the hostPath
+                            doesn't exist, then runtimes should report error. If the
+                            hostpath is a symbolic link, runtimes should follow the
+                            symlink and mount the real destination to container.
+                          type: string
+                        readOnly:
+                          description: If set, the mount is read-only.
+                          type: boolean
+                      type: object
+                    type: array
+                  preLoadImages:
+                    description: PreLoadImages allows to pre-load images in a newly
+                      created machine. This can be used to speed up tests by avoiding
+                      e.g. to download CNI images on all the containers.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+          status:
+            description: DockerMachinePoolStatus defines the observed state of DockerMachinePool.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the DockerMachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              infrastructureMachineKind:
+                description: InfrastructureMachineKind is the kind of the infrastructure
+                  resources behind MachinePool Machines.
+                type: string
+              instances:
+                description: Instances contains the status for each instance in the
+                  pool
+                items:
+                  description: DockerMachinePoolInstanceStatus contains status information
+                    about a DockerMachinePool.
+                  properties:
+                    addresses:
+                      description: Addresses contains the associated addresses for
+                        the docker machine.
+                      items:
+                        description: MachineAddress contains information for the node's
+                          address.
+                        properties:
+                          address:
+                            description: The machine address.
+                            type: string
+                          type:
+                            description: Machine address type, one of Hostname, ExternalIP,
+                              InternalIP, ExternalDNS or InternalDNS.
+                            type: string
+                        required:
+                        - address
+                        - type
+                        type: object
+                      type: array
+                    bootstrapped:
+                      description: "Bootstrapped is true when the kubeadm bootstrapping
+                        has been run against this machine \n Deprecated: This field
+                        will be removed in the next apiVersion. When removing also
+                        remove from staticcheck exclude-rules for SA1019 in golangci.yml"
+                      type: boolean
+                    instanceName:
+                      description: InstanceName is the identification of the Machine
+                        Instance within the Machine Pool
+                      type: string
+                    providerID:
+                      description: ProviderID is the provider identification of the
+                        Machine Pool Instance
+                      type: string
+                    ready:
+                      description: Ready denotes that the machine (docker container)
+                        is ready
+                      type: boolean
+                    version:
+                      description: Version defines the Kubernetes version for the
+                        Machine Instance
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the machine pool is ready
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: dockermachinepooltemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerMachinePoolTemplate
+    listKind: DockerMachinePoolTemplateList
+    plural: dockermachinepooltemplates
+    singular: dockermachinepooltemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachinePoolTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerMachinePoolTemplate is the Schema for the dockermachinepooltemplates
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachinePoolTemplateSpec defines the desired state of
+              DockerMachinePoolTemplate.
+            properties:
+              template:
+                description: DockerMachinePoolTemplateResource describes the data
+                  needed to create a DockerMachine from a template.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: DockerMachinePoolSpec defines the desired state of
+                      DockerMachinePool.
+                    properties:
+                      providerID:
+                        description: ProviderID is the identification ID of the Machine
+                          Pool
+                        type: string
+                      providerIDList:
+                        description: ProviderIDList is the list of identification
+                          IDs of machine instances managed by this Machine Pool
+                        items:
+                          type: string
+                        type: array
+                      template:
+                        description: Template contains the details used to build a
+                          replica machine within the Machine Pool
+                        properties:
+                          customImage:
+                            description: CustomImage allows customizing the container
+                              image that is used for running the machine
+                            type: string
+                          extraMounts:
+                            description: ExtraMounts describes additional mount points
+                              for the node container These may be used to bind a hostPath
+                            items:
+                              description: Mount specifies a host volume to mount
+                                into a container. This is a simplified version of
+                                kind v1alpha4.Mount types.
+                              properties:
+                                containerPath:
+                                  description: Path of the mount within the container.
+                                  type: string
+                                hostPath:
+                                  description: Path of the mount on the host. If the
+                                    hostPath doesn't exist, then runtimes should report
+                                    error. If the hostpath is a symbolic link, runtimes
+                                    should follow the symlink and mount the real destination
+                                    to container.
+                                  type: string
+                                readOnly:
+                                  description: If set, the mount is read-only.
+                                  type: boolean
+                              type: object
+                            type: array
+                          preLoadImages:
+                            description: PreLoadImages allows to pre-load images in
+                              a newly created machine. This can be used to speed up
+                              tests by avoiding e.g. to download CNI images on all
+                              the containers.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: dockermachines.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerMachine
+    listKind: DockerMachineList
+    plural: dockermachines
+    singular: dockermachine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "DockerMachine is the Schema for the dockermachines API. \n Deprecated:
+          This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachineSpec defines the desired state of DockerMachine.
+            properties:
+              bootstrapped:
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
+                type: boolean
+              customImage:
+                description: CustomImage allows customizing the container image that
+                  is used for running the machine
+                type: string
+              extraMounts:
+                description: ExtraMounts describes additional mount points for the
+                  node container These may be used to bind a hostPath
+                items:
+                  description: Mount specifies a host volume to mount into a container.
+                    This is a simplified version of kind v1alpha4.Mount types.
+                  properties:
+                    containerPath:
+                      description: Path of the mount within the container.
+                      type: string
+                    hostPath:
+                      description: Path of the mount on the host. If the hostPath
+                        doesn't exist, then runtimes should report error. If the hostpath
+                        is a symbolic link, runtimes should follow the symlink and
+                        mount the real destination to container.
+                      type: string
+                    readOnly:
+                      description: If set, the mount is read-only.
+                      type: boolean
+                  type: object
+                type: array
+              preLoadImages:
+                description: PreLoadImages allows to pre-load images in a newly created
+                  machine. This can be used to speed up tests by avoiding e.g. to
+                  download CNI images on all the containers.
+                items:
+                  type: string
+                type: array
+              providerID:
+                description: ProviderID will be the container name in ProviderID format
+                  (docker:////<containername>)
+                type: string
+            type: object
+          status:
+            description: DockerMachineStatus defines the observed state of DockerMachine.
+            properties:
+              addresses:
+                description: Addresses contains the associated addresses for the docker
+                  machine.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the DockerMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              loadBalancerConfigured:
+                description: LoadBalancerConfigured denotes that the machine has been
+                  added to the load balancer
+                type: boolean
+              ready:
+                description: Ready denotes that the machine (docker container) is
+                  ready
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Machine object which owns with this DockerMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Time duration since creation of DockerMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerMachine is the Schema for the dockermachines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachineSpec defines the desired state of DockerMachine.
+            properties:
+              bootstrapped:
+                description: "Bootstrapped is true when the kubeadm bootstrapping
+                  has been run against this machine \n Deprecated: This field will
+                  be removed in the next apiVersion. When removing also remove from
+                  staticcheck exclude-rules for SA1019 in golangci.yml."
+                type: boolean
+              customImage:
+                description: CustomImage allows customizing the container image that
+                  is used for running the machine
+                type: string
+              extraMounts:
+                description: ExtraMounts describes additional mount points for the
+                  node container These may be used to bind a hostPath
+                items:
+                  description: Mount specifies a host volume to mount into a container.
+                    This is a simplified version of kind v1alpha4.Mount types.
+                  properties:
+                    containerPath:
+                      description: Path of the mount within the container.
+                      type: string
+                    hostPath:
+                      description: Path of the mount on the host. If the hostPath
+                        doesn't exist, then runtimes should report error. If the hostpath
+                        is a symbolic link, runtimes should follow the symlink and
+                        mount the real destination to container.
+                      type: string
+                    readOnly:
+                      description: If set, the mount is read-only.
+                      type: boolean
+                  type: object
+                type: array
+              preLoadImages:
+                description: PreLoadImages allows to pre-load images in a newly created
+                  machine. This can be used to speed up tests by avoiding e.g. to
+                  download CNI images on all the containers.
+                items:
+                  type: string
+                type: array
+              providerID:
+                description: ProviderID will be the container name in ProviderID format
+                  (docker:////<containername>)
+                type: string
+            type: object
+          status:
+            description: DockerMachineStatus defines the observed state of DockerMachine.
+            properties:
+              addresses:
+                description: Addresses contains the associated addresses for the docker
+                  machine.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the DockerMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              loadBalancerConfigured:
+                description: LoadBalancerConfigured denotes that the machine has been
+                  added to the load balancer
+                type: boolean
+              ready:
+                description: Ready denotes that the machine (docker container) is
+                  ready
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: dockermachinetemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerMachineTemplate
+    listKind: DockerMachineTemplateList
+    plural: dockermachinetemplates
+    singular: dockermachinetemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachineTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "DockerMachineTemplate is the Schema for the dockermachinetemplates
+          API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.
+            properties:
+              template:
+                description: DockerMachineTemplateResource describes the data needed
+                  to create a DockerMachine from a template.
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      bootstrapped:
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
+                        type: boolean
+                      customImage:
+                        description: CustomImage allows customizing the container
+                          image that is used for running the machine
+                        type: string
+                      extraMounts:
+                        description: ExtraMounts describes additional mount points
+                          for the node container These may be used to bind a hostPath
+                        items:
+                          description: Mount specifies a host volume to mount into
+                            a container. This is a simplified version of kind v1alpha4.Mount
+                            types.
+                          properties:
+                            containerPath:
+                              description: Path of the mount within the container.
+                              type: string
+                            hostPath:
+                              description: Path of the mount on the host. If the hostPath
+                                doesn't exist, then runtimes should report error.
+                                If the hostpath is a symbolic link, runtimes should
+                                follow the symlink and mount the real destination
+                                to container.
+                              type: string
+                            readOnly:
+                              description: If set, the mount is read-only.
+                              type: boolean
+                          type: object
+                        type: array
+                      preLoadImages:
+                        description: PreLoadImages allows to pre-load images in a
+                          newly created machine. This can be used to speed up tests
+                          by avoiding e.g. to download CNI images on all the containers.
+                        items:
+                          type: string
+                        type: array
+                      providerID:
+                        description: ProviderID will be the container name in ProviderID
+                          format (docker:////<containername>)
+                        type: string
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachineTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerMachineTemplate is the Schema for the dockermachinetemplates
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.
+            properties:
+              template:
+                description: DockerMachineTemplateResource describes the data needed
+                  to create a DockerMachine from a template.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      bootstrapped:
+                        description: "Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine \n Deprecated: This field
+                          will be removed in the next apiVersion. When removing also
+                          remove from staticcheck exclude-rules for SA1019 in golangci.yml."
+                        type: boolean
+                      customImage:
+                        description: CustomImage allows customizing the container
+                          image that is used for running the machine
+                        type: string
+                      extraMounts:
+                        description: ExtraMounts describes additional mount points
+                          for the node container These may be used to bind a hostPath
+                        items:
+                          description: Mount specifies a host volume to mount into
+                            a container. This is a simplified version of kind v1alpha4.Mount
+                            types.
+                          properties:
+                            containerPath:
+                              description: Path of the mount within the container.
+                              type: string
+                            hostPath:
+                              description: Path of the mount on the host. If the hostPath
+                                doesn't exist, then runtimes should report error.
+                                If the hostpath is a symbolic link, runtimes should
+                                follow the symlink and mount the real destination
+                                to container.
+                              type: string
+                            readOnly:
+                              description: If set, the mount is read-only.
+                              type: boolean
+                          type: object
+                        type: array
+                      preLoadImages:
+                        description: PreLoadImages allows to pre-load images in a
+                          newly created machine. This can be used to speed up tests
+                          by avoiding e.g. to download CNI images on all the containers.
+                        items:
+                          type: string
+                        type: array
+                      providerID:
+                        description: ProviderID will be the container name in ProviderID
+                          format (docker:////<containername>)
+                        type: string
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+  name: capd-manager
+  namespace: capd-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+  name: capd-leader-election-role
+  namespace: capd-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+  name: capd-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - machines
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockerclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockerclusters/finalizers
+  - dockerclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockermachinepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockermachinepools/finalizers
+  - dockermachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockermachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockermachines/finalizers
+  - dockermachines/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+  name: capd-leader-election-rolebinding
+  namespace: capd-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capd-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capd-manager
+  namespace: capd-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+  name: capd-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capd-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capd-manager
+  namespace: capd-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+  name: capd-webhook-service
+  namespace: capd-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-docker
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    control-plane: controller-manager
+  name: capd-controller-manager
+  namespace: capd-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: infrastructure-docker
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/provider: infrastructure-docker
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect=true
+        - --feature-gates=ClusterTopology=true
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: DOCKER_HOST
+        image: ghcr.io/sovereigncloudstack/capd:1.0.5
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /var/run/docker.sock
+          name: dockersock
+      serviceAccountName: capd-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capd-webhook-service-cert
+      - hostPath:
+          path: /var/run/docker.sock
+        name: dockersock
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+  name: capd-serving-cert
+  namespace: capd-system
+spec:
+  dnsNames:
+  - capd-webhook-service.capd-system.svc
+  - capd-webhook-service.capd-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capd-selfsigned-issuer
+  secretName: capd-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+  name: capd-selfsigned-issuer
+  namespace: capd-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+  name: capd-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capd-webhook-service
+      namespace: capd-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-dockercluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.dockercluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockerclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capd-webhook-service
+      namespace: capd-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-dockerclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.dockerclustertemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockerclustertemplates
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+  name: capd-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capd-webhook-service
+      namespace: capd-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-dockercluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.dockercluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockerclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capd-webhook-service
+      namespace: capd-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-dockerclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.dockerclustertemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockerclustertemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capd-webhook-service
+      namespace: capd-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-dockermachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.dockermachinetemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockermachinetemplates
+  sideEffects: None


### PR DESCRIPTION
users on fedora using btrfs filesystem were having issues with capd and that was fixed on main and it requires building your own image and using the same here for now.

I tested it by building the image locally and now I don't see any error. This will be fixed when we upgrade to 1.6.3 or later version. As of now, we will rely on image built from CAPI main branch and pushed to ghcr.io/sovereigncloudstack/capd with 1.0.5 tag.

