### PR TITLE
:sparkles: Add status resources for the helm charts

### DIFF
--- a/pkg/kube/fake/kube.go
+++ b/pkg/kube/fake/kube.go
@@ -50,10 +50,10 @@ func (*kube) Delete(_ context.Context, _ []byte, _ []*csov1alpha1.Resource) (_ [
 	return nil, false, nil
 }
 
-func (*kube) ApplyNewClusterStack(_ context.Context, _, _ []byte) (_ bool, _ error) {
-	return false, nil
+func (*kube) ApplyNewClusterStack(_ context.Context, _, _ []byte) (_ []*csov1alpha1.Resource, _ bool, _ error) {
+	return nil, false, nil
 }
 
-func (*kube) DeleteNewClusterStack(_ context.Context, _ []byte) (_ bool, _ error) {
-	return false, nil
+func (*kube) DeleteNewClusterStack(_ context.Context, _ []byte) (_ []*csov1alpha1.Resource, _ bool, _ error) {
+	return nil, false, nil
 }

--- a/pkg/kube/mocks/Client.go
+++ b/pkg/kube/mocks/Client.go
@@ -49,27 +49,36 @@ func (_m *Client) Apply(ctx context.Context, template []byte, oldResources []*v1
 }
 
 // ApplyNewClusterStack provides a mock function with given fields: ctx, oldTemplate, newTemplate
-func (_m *Client) ApplyNewClusterStack(ctx context.Context, oldTemplate []byte, newTemplate []byte) (bool, error) {
+func (_m *Client) ApplyNewClusterStack(ctx context.Context, oldTemplate []byte, newTemplate []byte) ([]*v1alpha1.Resource, bool, error) {
 	ret := _m.Called(ctx, oldTemplate, newTemplate)
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []byte, []byte) (bool, error)); ok {
+	var r0 []*v1alpha1.Resource
+	var r1 bool
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, []byte) ([]*v1alpha1.Resource, bool, error)); ok {
 		return rf(ctx, oldTemplate, newTemplate)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []byte, []byte) bool); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, []byte) []*v1alpha1.Resource); ok {
 		r0 = rf(ctx, oldTemplate, newTemplate)
 	} else {
-		r0 = ret.Get(0).(bool)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*v1alpha1.Resource)
+		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []byte, []byte) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, []byte, []byte) bool); ok {
 		r1 = rf(ctx, oldTemplate, newTemplate)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(bool)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, []byte, []byte) error); ok {
+		r2 = rf(ctx, oldTemplate, newTemplate)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // Delete provides a mock function with given fields: ctx, template, oldResources
@@ -106,27 +115,36 @@ func (_m *Client) Delete(ctx context.Context, template []byte, oldResources []*v
 }
 
 // DeleteNewClusterStack provides a mock function with given fields: ctx, template
-func (_m *Client) DeleteNewClusterStack(ctx context.Context, template []byte) (bool, error) {
+func (_m *Client) DeleteNewClusterStack(ctx context.Context, template []byte) ([]*v1alpha1.Resource, bool, error) {
 	ret := _m.Called(ctx, template)
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []byte) (bool, error)); ok {
+	var r0 []*v1alpha1.Resource
+	var r1 bool
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, []byte) ([]*v1alpha1.Resource, bool, error)); ok {
 		return rf(ctx, template)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []byte) bool); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []byte) []*v1alpha1.Resource); ok {
 		r0 = rf(ctx, template)
 	} else {
-		r0 = ret.Get(0).(bool)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*v1alpha1.Resource)
+		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []byte) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, []byte) bool); ok {
 		r1 = rf(ctx, template)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(bool)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, []byte) error); ok {
+		r2 = rf(ctx, template)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // NewClient creates a new instance of Client. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding status.resources to show better potential problems when objects are applied.

**Which issue(s) this PR fixes**:
Fixes #142

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

