### PR TITLE
:bug: Fix reset of HelmChartStatus of ClusterAddon

### DIFF
--- a/internal/controller/clusteraddon_controller.go
+++ b/internal/controller/clusteraddon_controller.go
@@ -306,7 +306,13 @@ func (r *ClusterAddonReconciler) Reconcile(ctx context.Context, req reconcile.Re
 		// if a hook is specified, we cannot be ready yet
 		// if a hook is set, it is expected that HelmChartAppliedCondition is removed
 		if clusterAddon.Spec.Hook != "" {
-			clusterAddon.Status.HelmChartStatus = make(map[string]csov1alpha1.HelmChartStatusConditions)
+			// if the clusterAddon was ready before, it means this hook is fresh and we have to reset the status
+			if clusterAddon.Status.Ready {
+				clusterAddon.Status.HelmChartStatus = make(map[string]csov1alpha1.HelmChartStatusConditions)
+			}
+			if clusterAddon.Status.HelmChartStatus == nil {
+				clusterAddon.Status.HelmChartStatus = make(map[string]csov1alpha1.HelmChartStatusConditions)
+			}
 			clusterAddon.Status.Ready = false
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In the previous PR we introduced a bug that resets the status in every reconcile loop as long as a hook is specified.

However, we only want to reset it once when the hook is new. 

**Which issue(s) this PR fixes**:
Fixes #154

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

