### PR TITLE
🌱 disable core k8s deps bumps via renovate

### DIFF
--- a/.github/renovate/golang.json5
+++ b/.github/renovate/golang.json5
@@ -31,9 +31,8 @@
     {
       description: "Disable update k8s packages",
       matchManagers: ["gomod"],
-      matchDepNames: ["k8s.io/api", "k8s.io/apimachinery", "k8s.io/apiserver", "k8s.io/client-go", "k8s.io/kubectl", "k8s.io/code-generator"],
-      matchUpdateTypes: ["patch"],
-      enabled: true,
+      matchDepNames: ["k8s.io/api", "k8s.io/apimachinery", "k8s.io/apiserver", "k8s.io/client-go", "k8s.io/kubectl", "k8s.io/code-generator", "k8s.io/klog/v2", "k8s.io/cli-runtime", "k8s.io/apiextensions-apiserver"],
+      enabled: false,
     },
     {
       description: "Disable update cluster-api",


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

this should only be updated with CAPI bump PRs. 

fixes these types of PRs https://github.com/SovereignCloudStack/cluster-stack-operator/pull/116

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

