### PR TITLE
:seedling: Add condition if waiting for hook server

### DIFF
--- a/api/v1alpha1/conditions_const.go
+++ b/api/v1alpha1/conditions_const.go
@@ -57,6 +57,14 @@ const (
 )
 
 const (
+	// HookServerReadyCondition reports on whether hook server is ready or not.
+	HookServerReadyCondition clusterv1.ConditionType = "HookServerReady"
+
+	// HookServerUnresponsiveReason is used when hook server don't update the clusterAddon.Spec.Hook.
+	HookServerUnresponsiveReason = "HookServerUnresponsive"
+)
+
+const (
 	// HelmChartDeletedCondition reports on whether the relevant helm chart has been applied.
 	HelmChartDeletedCondition clusterv1.ConditionType = "HelmChartDeleted"
 

--- a/internal/controller/clusteraddon_controller.go
+++ b/internal/controller/clusteraddon_controller.go
@@ -412,8 +412,15 @@ func (r *ClusterAddonReconciler) Reconcile(ctx context.Context, req reconcile.Re
 	// If hook is empty we can don't want to proceed executing staged according to current hook
 	// hence we can return.
 	if clusterAddon.Spec.Hook == "" {
+		conditions.MarkFalse(clusterAddon,
+			csov1alpha1.HookServerReadyCondition,
+			csov1alpha1.HookServerUnresponsiveReason,
+			clusterv1.ConditionSeverityInfo,
+			"hook server hasn't updated the spec.hook yet",
+		)
 		return reconcile.Result{}, nil
 	}
+	conditions.MarkTrue(clusterAddon, csov1alpha1.HookServerReadyCondition)
 
 	for _, stage := range clusterAddonConfig.AddonStages[clusterAddon.Spec.Hook] {
 		shouldRequeue, err := r.executeStage(ctx, stage, in)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a condition that indicates that we wait for the hook server or that the hook server is responsive.

**Which issue(s) this PR fixes**:
Fixes #193

**TODOs**:
- [x] squash commits
- [ ] include documentation
- [ ] add unit tests

