### PR TITLE
🌱 Use semver version in cluster stack status

### DIFF
--- a/internal/controller/clusterstack_controller.go
+++ b/internal/controller/clusterstack_controller.go
@@ -517,7 +517,7 @@ func getLatestReadyClusterStackRelease(clusterStackReleases []*csov1alpha1.Clust
 				return nil, "", fmt.Errorf("failed to get clusterstack from ClusterStackRelease.Name %q: %w", csr.Name, err)
 			}
 			clusterStackObjects = append(clusterStackObjects, cs)
-			mapKubernetesVersions[cs.String()] = csr.Status.KubernetesVersion
+			mapKubernetesVersions[cs.StringWithDot()] = csr.Status.KubernetesVersion
 		}
 	}
 
@@ -530,7 +530,7 @@ func getLatestReadyClusterStackRelease(clusterStackReleases []*csov1alpha1.Clust
 	sort.Sort((clusterStackObjects))
 
 	// return the latest one
-	cs := clusterStackObjects[len(clusterStackObjects)-1].String()
+	cs := clusterStackObjects[len(clusterStackObjects)-1].StringWithDot()
 	latest = &cs
 	k8sversion = mapKubernetesVersions[*latest]
 	return latest, k8sversion, nil
@@ -606,7 +606,7 @@ func getUsableClusterStackReleaseVersions(clusterStackReleases []*csov1alpha1.Cl
 				return nil, fmt.Errorf("failed to construct version from ClusterStackRelease.Name %q: %w", csr.Name, err)
 			}
 
-			usableVersions = append(usableVersions, v.String())
+			usableVersions = append(usableVersions, v.StringWithDot())
 		}
 	}
 	return usableVersions, nil

--- a/pkg/clusterstack/clusterstack.go
+++ b/pkg/clusterstack/clusterstack.go
@@ -198,7 +198,14 @@ func (cs *ClusterStack) Validate() error {
 	return nil
 }
 
+// String returns cluster stack with "-" notation.
 func (cs *ClusterStack) String() string {
 	// release tag: myprovider-myclusterstack-1-26-v1
 	return strings.Join([]string{cs.Provider, cs.Name, cs.KubernetesVersion.String(), cs.Version.String()}, Separator)
+}
+
+// StringWithDot returns cluster stack with semver "." notation.
+func (cs *ClusterStack) StringWithDot() string {
+	// release tag: myprovider-myclusterstack-1-26-v0-sha.hd237u2
+	return strings.Join([]string{cs.Provider, cs.Name, cs.KubernetesVersion.String(), cs.Version.StringWithDot()}, Separator)
 }


### PR DESCRIPTION
- clusterstack.status.latestRelease & clusterstack.status.usableVersion use semver ("." notation)

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #221 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

