### PR TITLE
:bug: Fix: Handle empty chart directory correctly

### DIFF
--- a/internal/controller/clusterstackrelease_controller.go
+++ b/internal/controller/clusterstackrelease_controller.go
@@ -151,6 +151,20 @@ func (r *ClusterStackReleaseReconciler) Reconcile(ctx context.Context, req recon
 		return reconcile.Result{Requeue: true}, nil
 	}
 
+	// Check for helm charts in the release assets. If they are not present, then something went wrong.
+	if err := releaseAssets.CheckHelmCharts(); err != nil {
+		msg := fmt.Sprintf("failed to validate helm charts: %s", err.Error())
+		conditions.MarkFalse(
+			clusterStackRelease,
+			csov1alpha1.ClusterStackReleaseAssetsReadyCondition,
+			csov1alpha1.IssueWithReleaseAssetsReason,
+			clusterv1.ConditionSeverityError,
+			"%s", msg,
+		)
+		record.Warn(clusterStackRelease, "ValidateHelmChartFailed", msg)
+		return reconcile.Result{}, nil
+	}
+
 	conditions.MarkTrue(clusterStackRelease, csov1alpha1.ClusterStackReleaseAssetsReadyCondition)
 
 	kubeClient := r.KubeClientFactory.NewClient(req.Namespace, r.RESTConfig)
@@ -304,7 +318,10 @@ func (r *ClusterStackReleaseReconciler) templateAndApply(ctx context.Context, re
 
 // templateClusterClassHelmChart templates the clusterClass helm chart.
 func (*ClusterStackReleaseReconciler) templateClusterClassHelmChart(releaseAssets *release.Release, name, namespace string) ([]byte, error) {
-	clusterClassChart := releaseAssets.ClusterClassChartPath()
+	clusterClassChart, e := releaseAssets.ClusterClassChartPath()
+	if e != nil {
+		return nil, fmt.Errorf("failed to template clusterClass helm chart: %w", e)
+	}
 
 	splittedName := strings.Split(name, clusterstack.Separator)
 	releaseName := strings.Join(splittedName[0:4], clusterstack.Separator)

--- a/pkg/release/release.go
+++ b/pkg/release/release.go
@@ -159,6 +159,7 @@ func ensureMetadata(downloadPath, metadataFileName string) (Metadata, error) {
 func (r *Release) CheckHelmCharts() error {
 	// check if the cluster class chart is present.
 	clusterClassChartName := r.clusterClassChartName()
+
 	clusterClassChartPath, err := r.helmChartNamePath(clusterClassChartName)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster class chart path: %w", err)
@@ -171,12 +172,6 @@ func (r *Release) CheckHelmCharts() error {
 	if _, err := os.Stat(clusterAddonPath); err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("failed to verify the clusteraddon.yaml path %s with error: %w", clusterAddonPath, err)
-		}
-
-		// check if the cluster addon values file is present.
-		valuesPath := filepath.Join(r.LocalDownloadPath, ClusterAddonValuesName)
-		if _, err := os.Stat(valuesPath); err != nil {
-			return fmt.Errorf("failed to verify the cluster addon values path %s with error: %w", valuesPath, err)
 		}
 	}
 
@@ -238,11 +233,11 @@ func (r *Release) clusterClassChartName() string {
 }
 
 // ClusterClassChartPath returns the absolute helm chart path for cluster class.
-func (r *Release) ClusterClassChartPath() string {
+func (r *Release) ClusterClassChartPath() (string, error) {
 	nameFilter := r.clusterClassChartName()
-	// we ignore the error here, since we already checked for the presence of the chart.
-	path, _ := r.helmChartNamePath(nameFilter)
-	return path
+
+	path, err := r.helmChartNamePath(nameFilter)
+	return path, err
 }
 
 // helmChartNamePath returns the helm chart name from the given path.


### PR DESCRIPTION
Currently the return of helmChartNamePath is not checked on errors. This means that the CSO tries to helm template the container which leads to cryptic error messages from helm.

This commit adds a check on errors on the call to helmChartNamePath and results in more helpful error messages by helm.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #288 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

The log message after the patch is more helpful:

```
{"level":"ERROR","time":"2025-04-14T15:28:57.491Z","file":"controller/controller.go:324","message":"Reconciler error","controller":"clusterstackrelease","controllerGroup":"clusterstack.x-k8s.io","controllerKind":"ClusterStackRelease","ClusterStackRelease":{"name":"docker-example-1-32-v0-sha-uxh53fj","namespace":"default"},"namespace":"default","name":"docker-example-1-32-v0-sha-uxh53fj","reconcileID":"584d729e-a19f-4dbd-9c1d-5a45df7edc21","error":"failed to template and apply: failed to template clusterClass helm chart: failed to template clusterClass helm chart: helm chart matching the name filter docker-example-1-32-cluster-class-v0-sha.uxh53fj not found in /tmp/downloads/cluster-stacks/docker-example-1-32-v0-sha-uxh53fj","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/home/jakl/GolandProjects/cluster-stack-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:324\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/jakl/GolandProjects/cluster-stack-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:261\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/home/jakl/GolandProjects/cluster-stack-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:222"}
{"level":"INFO","time":"2025-04-14T15:30:13.992Z","file":"fake/client.go:58","message":"WARNING: called DownloadReleaseAssets of fake assets client","controller":"clusterstackrelease","controllerGroup":"clusterstack.x-k8s.io","controllerKind":"ClusterStackRelease","ClusterStackRelease":{"name":"docker-ferrol-1-27-v2","namespace":"cluster"},"namespace":"cluster","name":"docker-ferrol-1-27-v2","reconcileID":"24134593-9a09-4a19-b8dd-0b5f92e09ee6"}
```


**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

