### PR TITLE
:seedling:  Bump golang version in build image from 1.23.5-bullseye to 1.24.6-bullseye

### DIFF
--- a/images/cso/Dockerfile
+++ b/images/cso/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=${BUILDPLATFORM} docker.io/alpine/helm:3.19.0 as helm
+FROM --platform=${BUILDPLATFORM} docker.io/alpine/helm:3.19.0 AS helm
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.24.6-bullseye as build
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.24.6-bullseye AS build
 ARG TARGETOS TARGETARCH
 
 COPY . /src/cluster-stack-operator

--- a/images/cso/Dockerfile
+++ b/images/cso/Dockerfile
@@ -15,7 +15,7 @@
 FROM --platform=${BUILDPLATFORM} docker.io/alpine/helm:3.19.0 as helm
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.23.5-bullseye as build
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.24.6-bullseye as build
 ARG TARGETOS TARGETARCH
 
 COPY . /src/cluster-stack-operator


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Fixes CSO-0.2 img build failure: https://github.com/SovereignCloudStack/cluster-stack-operator/actions/runs/17912013752/job/50929794430

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
